### PR TITLE
Fix training crash with custom batch size

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -35,7 +35,7 @@ class listDataset(Dataset):
         assert index <= len(self), 'index range error'
         imgpath = self.lines[index].rstrip()
 
-        if self.train and index % 64== 0:
+        if self.train and index % self.batch_size == 0:
             if self.seen < 4000*64:
                width = 13*32
                self.shape = (width, width)


### PR DESCRIPTION
May (and, very probably, will) crash if image shape changes amid batch