### PR TITLE
Revert "Fix training crash with custom batch size"

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -35,7 +35,7 @@ class listDataset(Dataset):
         assert index <= len(self), 'index range error'
         imgpath = self.lines[index].rstrip()
 
-        if self.train and index % self.batch_size == 0:
+        if self.train and index % 64== 0:
             if self.seen < 4000*64:
                width = 13*32
                self.shape = (width, width)


### PR DESCRIPTION
Reverts andy-yun/pytorch-0.4-yolov3#2

Because the __getitem__ is called in every iteration,
the image augmented for every 64 images.
Some cases, batch_size is 1, then all images are resized. 
This is not the case we expected.